### PR TITLE
Fix typo in decodeMPX() declaration.

### DIFF
--- a/src/IRrecv.h
+++ b/src/IRrecv.h
@@ -270,7 +270,7 @@ class IRrecv {
                        bool strict = true);
 #endif
 #if DECODE_MPX
-  bool decodeMpx(decode_results *results, uint16_t nbits = 16,
+  bool decodeMPX(decode_results *results, uint16_t nbits = MPX_BITS,
                    bool strict = true);
 #endif
 };


### PR DESCRIPTION
and use the #define for the bit size.